### PR TITLE
Fix routers getting stuck assigned

### DIFF
--- a/fuconfig/orgs-update.php
+++ b/fuconfig/orgs-update.php
@@ -1,87 +1,44 @@
 <?php
 
-include_once('FUConfig.php');
+include_once ('FUConfig.php');
 
 $currentRequest = new PageRequest($_REQUEST);
-
 
 $org = new Org();
 $org->LoadFromPageRequest($currentRequest);
 var_dump($org);
 
-if ($currentRequest->IsUpdateRequest() Or $currentRequest->IsCreateRequest()) {
-	$org->SaveToDB();
+if ($currentRequest->IsUpdateRequest() or $currentRequest->IsCreateRequest()) {
+  $org->SaveToDB();
 } else if ($currentRequest->IsDeleteRequest()) {
-	//First check to make sure there are no phones assigned.
-	$org_id = $currentRequest->GetID();
+  // First check to make sure there are no phones assigned.
+  $org_id = $currentRequest->GetID();
 
-	$phoneList = new PhoneList();
-	$phoneList->LoadOrgPhones($org_id);
+  $phoneList = new PhoneList();
+  $phoneList->LoadOrgPhones($org_id);
 
-	echo $phoneList->GetCount();
+  echo $phoneList->GetCount();
 
-	if ($phoneList->GetCount() == 0) {
-		$org->LoadFromDB($org_id);
-		$org->DeleteFromDB();
-
-
-
+  if ($phoneList->GetCount() == 0) {
+    $org->LoadFromDB($org_id);
+    $org->DeleteFromDB();
+  } else {
+    $trace = debug_backtrace();
+    trigger_error(
+      'Cannot delete org with assigned phones: ' .
+      ' in ' . $trace[0]['file'] .
+      ' on line ' . $trace[0]['line'],
+      E_USER_ERROR
+    );
+  }
 } else {
-	$trace = debug_backtrace();
-	trigger_error(
-		'Cannot delete org with assigned phones: ' .
-		' in ' . $trace[0]['file'] .
-		' on line ' . $trace[0]['line'],
-		E_USER_ERROR);
-	}
-} else {
-	$trace = debug_backtrace();
-	trigger_error(
-		'Invalid request type: ' .
-		' in ' . $trace[0]['file'] .
-		' on line ' . $trace[0]['line'],
-		E_USER_ERROR);
+  $trace = debug_backtrace();
+  trigger_error(
+    'Invalid request type: ' .
+    ' in ' . $trace[0]['file'] .
+    ' on line ' . $trace[0]['line'],
+    E_USER_ERROR
+  );
 }
 
 Redirect('/index.php');
-
-/*
-include_once('includes/defaults.php');
-include_once('includes/db.php');
-
-if (isset($_GET['edit'])) {
-
-	$editQuery = "UPDATE orgs SET org_name = :name, org_contactname = :contactname,
-						org_contactphone = :contactphone, org_contactemail = :contactemail
-					WHERE org_id = :id;";
-
-	$editStmt = $pdo->prepare($editQuery);
-	$editStmt->execute(['id' => $_POST['id'], 'name' => $_POST['name'], 'contactname' => $_POST['contactname'],
-		'contactemail' => $_POST['contactemail'], 'contactphone' => $_POST['contactphone']]);
-
-	Redirect('/index.php');
-
-
-} else if (isset($_GET['add'])) {
-
-	$addQuery = "INSERT INTO orgs (org_name, org_contactname, org_contactemail, org_contactphone)
-					VALUES (:name, :contactname, :contactemail, :contactphone);";
-
-	$addStmt = $pdo->prepare($addQuery);
-	$addStmt->execute(['name' => $_POST['name'], 'contactname' => $_POST['contactname'],
-		'contactemail' => $_POST['contactemail'], 'contactphone' => $_POST['contactphone']]);
-
-	Redirect('/index.php');
-
-} else if (isset($_GET['delete'])) {
-
-	$delQuery = "DELETE FROM orgs WHERE org_id = ?;";
-	$delStmt = $pdo->prepare($delQuery);
-	$delStmt->execute([$_GET['id']]);
-
-}*/
-
-
-
-
-?>

--- a/fuconfig/orgs-update.php
+++ b/fuconfig/orgs-update.php
@@ -36,6 +36,7 @@ function handleDeleteRequest(PageRequest $request, Org $org): void
 {
   $org_id = $request->GetID();
   throwIfOrgHasPhonesAssigned($org_id);
+  throwIfOrgHasRoutersAssigned($org_id);
 
   $org->LoadFromDB($org_id);
   $org->DeleteFromDB();
@@ -53,6 +54,15 @@ function throwIfOrgHasPhonesAssigned(string $org_id): void
 
   if ($phoneList->GetCount() > 0) {
     throwErrorWithMessage('Cannot delete org with assigned phones');
+  }
+}
+function throwIfOrgHasRoutersAssigned(string $org_id): void
+{
+  $routerList = new RouterList();
+  $routerList->LoadByOrgId($org_id);
+
+  if ($routerList->GetCount() > 0) {
+    throwErrorWithMessage('Cannot delete org with assigned routers');
   }
 }
 


### PR DESCRIPTION
This pull request refactors `orgs-update.php` and makes the file throw an error when a user attempts to delete an organization that still has routers assigned to it.

# Manual Testing

I tried to delete an organization that contains a router:
<img width="955" alt="delete_button_and_router" src="https://github.com/spencerflem/fu-telecom/assets/67563877/0a97a6ba-39a4-40e7-847b-65d8366bd4f7">

The error page popped up:
<img width="960" alt="error_page" src="https://github.com/spencerflem/fu-telecom/assets/67563877/2eba178f-3f21-4ab8-9a96-8ad24b0792cb">

I deleted the router, then deleted the org, then checked the routers list. The router is available to assign!
<img width="960" alt="router_available" src="https://github.com/spencerflem/fu-telecom/assets/67563877/738514ba-a96f-44b1-8c41-a9da9d3aaf6c">
